### PR TITLE
Change http status error codes

### DIFF
--- a/internal/app/net/http.go
+++ b/internal/app/net/http.go
@@ -185,7 +185,7 @@ func (s *Http) createMetric(w http.ResponseWriter, r *http.Request) {
 
 	// Return a bad request if useragent is a bot
 	if isBot(r.UserAgent()) {
-		http.Error(w, "Event request denied due to known bot", http.StatusBadRequest)
+		http.Error(w, "Event request denied due to known bot", http.StatusForbidden)
 		return
 	}
 
@@ -207,7 +207,7 @@ func (s *Http) createMetric(w http.ResponseWriter, r *http.Request) {
 		// Format error message
 		errorMessage := fmt.Sprintf("%s - %s, Usage stats cannot be processed", eventRequest.Pid, err.Error())
 
-		http.Error(w, errorMessage, http.StatusBadRequest)
+		http.Error(w, errorMessage, http.StatusUnprocessableEntity)
 
 		return
 	}


### PR DESCRIPTION
To change the http status codes returned when an event is tracked in the backend for Usage Tracking.

## Purpose
In order to be clearer as to what triggers what errors, it is desirable http status codes are clearer when tracking events from the datacite-tracker.

The 3 possible event tracking errors:
1. Is a bot
2. The request is malformed (i.e. json doesn't parse)
3. Validation of DOI url is requested and it does not validate.

## Approach

Use Forbidden/BadRequest/Unprocessable as appropriate.

While arguably all could be associated with a BadRequest (400), the change here is still acceptable and will also have added benefit of anyone on client side having clearer error codes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
