### PR TITLE
Order results by PID in BreakdownByPID query

### DIFF
--- a/internal/app/stats/repository.go
+++ b/internal/app/stats/repository.go
@@ -136,6 +136,7 @@ func (repository *StatsRepository) BreakdownByPID(repoId string, query Query, pa
 		).Table("time_period_deduped").
 		Select("pid, countIf(name = 'view') as total_views, uniqIf(session_id, name = 'view') as unique_views, countIf(name = 'download') as total_downloads, uniqIf(session_id, name = 'download') as unique_downloads").
 		Group("pid").
+		Order("pid").
 		Scopes(Paginate(page, pageSize)).
 		Scan(&result)
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

This PR adds a deterministic sort order to the BreakdownByPid query, which is used to generate reports:

https://github.com/datacite/keeshond/blob/main/internal/app/reports/service.go

The theory is that repeat paginated BreakdownByPid queries may be skipping some PIDs because the row order for the query is non-deterministic without an ORDER BY, causing [the bug below](https://github.com/datacite/datacite/issues/2497). From the Clickhouse documentation: 

https://clickhouse.com/docs/sql-reference/statements/select/order-by

> Rows with identical values for a sort expressions are returned in an arbitrary and non-deterministic order. If the ORDER BY clause is omitted in a SELECT statement, the row order is also arbitrary and non-deterministic.

This theory seems to be supported by the fact that DOIs are repeated within a single report. For instance, for report  `37f28738-4752-45c6-9e54-1dac4d19d0d3`, there are 4671 duplicate DOIs across both report_subsets. The following is report from jq with the indices where the duplicates are found. Some can appear three times in the same report.

```
[
  {
    "dataset_id": "10.15146/R39W22",
    "count": 2,
    "found_at_indices": [
      41821,
      48265
    ]
  },
  {
    "dataset_id": "10.15146/R3DW20",
    "count": 2,
    "found_at_indices": [
      15304,
      22055
    ]
  },
  {
    "dataset_id": "10.15146/R3FG6P",
    "count": 2,
    "found_at_indices": [
      40446,
      46009
    ]
  },
  {
    "dataset_id": "10.15146/R3H09M",
    "count": 2,
    "found_at_indices": [
      31723,
      33134
    ]
  },
  {
    "dataset_id": "10.15146/R3J38K",
    "count": 2,
    "found_at_indices": [
      24913,
      28165
    ]
  },
  {
    "dataset_id": "10.15146/R3J66V",
    "count": 2,
    "found_at_indices": [
      40831,
      45222
    ]
  },
. . .
  {
    "dataset_id": "10.5061/dryad.zw3r228dh",
    "count": 2,
    "found_at_indices": [
      16929,
      17105
    ]
  },
  {
    "dataset_id": "10.5061/dryad.zw3r228g8",
    "count": 2,
    "found_at_indices": [
      25035,
      32201
    ]
  },
  {
    "dataset_id": "10.5061/dryad.zw3r228hr",
    "count": 2,
    "found_at_indices": [
      23522,
      31270
    ]
  },
  {
    "dataset_id": "10.5061/dryad.zw3r228k9",
    "count": 2,
    "found_at_indices": [
      40492,
      46055
    ]
  },
. . .
  {
    "dataset_id": "10.7291/D1TQ1P",
    "count": 3,
    "found_at_indices": [
      37633,
      38063,
      42787
    ]
  },
  {
    "dataset_id": "10.7291/D1VQ3R",
    "count": 2,
    "found_at_indices": [
      29534,
      44396
    ]
  },
  {
    "dataset_id": "10.7291/D1W093",
    "count": 2,
    "found_at_indices": [
      32538,
      34153
    ]
  },
  {
    "dataset_id": "10.7291/D1Z40P",
    "count": 2,
    "found_at_indices": [
      31346,
      37016
    ]
  }
]
```

closes: https://github.com/datacite/datacite/issues/2497

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
